### PR TITLE
Simulator on real Postgres DB

### DIFF
--- a/db/src/main/scala/slick/PostgresSlickDb.scala
+++ b/db/src/main/scala/slick/PostgresSlickDb.scala
@@ -2,25 +2,29 @@ package slick
 
 import cats.effect.{Async, Resource, Sync}
 import org.apache.commons.dbcp2.BasicDataSource
-import sdk.syntax.all.*
 import slick.jdbc.JdbcBackend.Database
 import slick.jdbc.PostgresProfile
 import slick.migration.api.PostgresDialect
 
 object PostgresSlickDb {
-  def apply[F[_]: Async](dbName: String, dbUser: String, dbPassword: String): Resource[F, SlickDb] =
+  def apply[F[_]: Async](
+    dbUrl: String,
+    dbUser: String,
+    dbPassword: String,
+    initialConnections: Int,
+    maxIdleConnections: Int,
+    maxTotalConnections: Int,
+  ): Resource[F, SlickDb] =
     Resource
       .make(Sync[F].delay {
-        Class.forName("org.postgresql.Driver").void()
-
         val dataSource = new BasicDataSource()
         dataSource.setDriverClassName("org.postgresql.Driver")
-        dataSource.setUrl(s"jdbc:postgresql://localhost:5432/$dbName")
+        dataSource.setUrl(dbUrl)
         dataSource.setUsername(dbUser)
         dataSource.setPassword(dbPassword)
-        dataSource.setMaxTotal(20)
-        dataSource.setMaxIdle(10)
-        dataSource.setInitialSize(10)
+        dataSource.setInitialSize(initialConnections)
+        dataSource.setMaxIdle(maxIdleConnections)
+        dataSource.setMaxTotal(maxTotalConnections)
 
         Database.forDataSource(dataSource, None)
       })(db => Sync[F].delay(db.close()))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -114,15 +114,16 @@ object Dependencies {
   val endpointsOpenApi   = "org.endpoints4s" %% "openapi"             % "4.4.0"
 
   // Database
-  val junitJupiter         = "org.junit.jupiter" % "junit-jupiter-api" % "5.10.0" % Test
-  val postgresql           = "org.postgresql"    % "postgresql"        % "42.6.0"
-  val h2db                 = "com.h2database"    % "h2"                % "2.1.214"
+  val junitJupiter         = "org.junit.jupiter"  % "junit-jupiter-api" % "5.10.0" % Test
+  val postgresql           = "org.postgresql"     % "postgresql"        % "42.6.0"
+  val h2db                 = "com.h2database"     % "h2"                % "2.1.214"
   val slick: Seq[ModuleID] = Seq(
     "com.typesafe.slick"                 %% "slick"               % "3.4.1",
     "org.slf4j"                           % "slf4j-nop"           % "2.0.5",
     "com.typesafe.slick"                 %% "slick-hikaricp"      % "3.4.1",
     "io.github.nafg.slick-migration-api" %% "slick-migration-api" % "0.9.0",// Migration tool for Slick
   )
+  val dbcp2                = "org.apache.commons" % "commons-dbcp2"     % "2.9.0"
 
   // Cryptography
   val bcprov = "org.bouncycastle" % "bcprov-jdk15on" % "1.68"
@@ -147,5 +148,5 @@ object Dependencies {
 
   val tests = Seq(scalatest, scalatest_ce, mockito, scalacheck_e, scalacheckShapeless, scalatestScalacheck, embedPgsql)
 
-  val dbLibs = Seq(h2db, postgresql, junitJupiter) ++ slick
+  val dbLibs = Seq(h2db, postgresql, junitJupiter, dbcp2) ++ slick
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -116,7 +116,6 @@ object Dependencies {
   // Database
   val junitJupiter         = "org.junit.jupiter"  % "junit-jupiter-api" % "5.10.0" % Test
   val postgresql           = "org.postgresql"     % "postgresql"        % "42.6.0"
-  val h2db                 = "com.h2database"     % "h2"                % "2.1.214"
   val slick: Seq[ModuleID] = Seq(
     "com.typesafe.slick"                 %% "slick"               % "3.4.1",
     "org.slf4j"                           % "slf4j-nop"           % "2.0.5",
@@ -148,5 +147,5 @@ object Dependencies {
 
   val tests = Seq(scalatest, scalatest_ce, mockito, scalacheck_e, scalacheckShapeless, scalatestScalacheck, embedPgsql)
 
-  val dbLibs = Seq(h2db, postgresql, junitJupiter, dbcp2) ++ slick
+  val dbLibs = Seq(postgresql, junitJupiter, dbcp2) ++ slick
 }

--- a/sim/src/main/scala/sim/NetworkSim.scala
+++ b/sim/src/main/scala/sim/NetworkSim.scala
@@ -287,7 +287,16 @@ object NetworkSim extends IOApp {
       lfs.state.bonds.activeSet.toList.traverse(mkNode(_, db))
 
     Stream
-      .resource(slick.PostgresSlickDb[F](nodeCfg.dbName, nodeCfg.dbUser, nodeCfg.dbPassword))
+      .resource(
+        slick.PostgresSlickDb[F](
+          s"jdbc:postgresql://localhost:5432/${nodeCfg.dbName}",
+          nodeCfg.dbUser,
+          nodeCfg.dbPassword,
+          10,
+          10,
+          20,
+        ),
+      )
       .flatMap { db =>
         Stream
           .resource(mkNet(lfs, db))

--- a/sim/src/main/scala/sim/balances/Serialization.scala
+++ b/sim/src/main/scala/sim/balances/Serialization.scala
@@ -1,15 +1,14 @@
 package sim.balances
 
-import cats.Monad
 import cats.syntax.all.*
+import cats.{Applicative, Monad}
 import dproc.data.Block
 import sdk.api.data.TokenTransferRequest
 import sdk.codecs.{PrimitiveReader, PrimitiveWriter, Serialize}
 import sdk.primitive.ByteArray
 import sim.balances.data.{BalancesDeploy, BalancesDeployBody, BalancesState}
 import sim.NetworkSim.*
-import weaver.data.ConflictResolution
-import weaver.data.Bonds
+import weaver.data.{Bonds, ConflictResolution}
 
 object Serialization {
   implicit def balancesStateSerialize[F[_]: Monad]: Serialize[F, BalancesState] =
@@ -166,6 +165,8 @@ object Serialization {
         } yield TokenTransferRequest(pubKey, digest, signature, signatureAlg, body)
     }
 
-  private def serializeSeq[F[_]: Monad, A: Ordering](l: Seq[A], writeF: A => F[Unit]): F[Unit] =
+  // This function is needed to work around the problem with `traverse_`
+  // See more examples here: https://gist.github.com/nzpr/38f843139224d1de1f0e9d15c75e925c
+  private def serializeSeq[F[_]: Applicative, A: Ordering](l: Seq[A], writeF: A => F[Unit]): F[Unit] =
     l.sorted.map(writeF).fold(().pure[F])(_ *> _)
 }

--- a/sim/src/main/scala/sim/balances/dbApiImpl.scala
+++ b/sim/src/main/scala/sim/balances/dbApiImpl.scala
@@ -119,8 +119,8 @@ object dbApiImpl {
   private val ProtocolVersion  = 0
   private val SigAlg           = ""
   private val SignatureDefault = ByteArray.Default
-  private val LazTolDefault    = 0
-  private val ExpThreshDefault = 0
+  private val LazTolDefault    = 1
+  private val ExpThreshDefault = 10000
   private val ShardNameDefault = "root"
   private val SeqNumDefault    = 0L
 


### PR DESCRIPTION
## Overview

Added small fixes to run the simulator on a real database.

The `lazinessTolerance` and `expirationThreshold` values ​​are filled with the values ​​`1` and `10000` as in NetworkSim.scala, since they are not saved anywhere in the database.

Data serialization uses a eager approach because the serialized data is consumed immediately.

### Please make sure that this PR:

- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
