### PR TITLE
DB queries optimization

### DIFF
--- a/db/src/main/scala/slick/Actions.scala
+++ b/db/src/main/scala/slick/Actions.scala
@@ -259,7 +259,7 @@ final case class Actions(profile: JdbcProfile, ec: ExecutionContext) {
       (qBlockSets.map(_.hash) returning qBlockSets.map(_.id)) += hash
 
     def getBlockIdsByHashes(hashes: Seq[Array[Byte]]): DBIOAction[Seq[Long], NoStream, Read] =
-      qBlocks.filter(_.hash inSet hashes).map(_.id).result
+      DBIO.sequence(hashes.map(queries.blockIdByHash(_).result.headOption)).map(_.flatten)
 
     def insertBinds(blockSetId: Long, blockIds: Seq[Long]): DBIOAction[Option[Int], NoStream, Write] = {
       val binds = blockIds.map(TableBlockSetBinds.BlockSetBind(blockSetId, _))

--- a/db/src/main/scala/slick/Queries.scala
+++ b/db/src/main/scala/slick/Queries.scala
@@ -27,8 +27,6 @@ final case class Queries(profile: JdbcProfile) {
 
   val deployIdBySig = Compiled((sig: Rep[Array[Byte]]) => deployBySig.extract(sig).map(_.id))
 
-  def deployIdsBySigs(sigs: Seq[Array[Byte]]) = Compiled(qDeploys.filter(_.sig inSet sigs).map(_.id))
-
   val deployWithDataBySig = Compiled((sig: Rep[Array[Byte]]) =>
     for {
       deploy   <- deployBySig.extract(sig)

--- a/db/src/main/scala/slick/Queries.scala
+++ b/db/src/main/scala/slick/Queries.scala
@@ -43,6 +43,8 @@ final case class Queries(profile: JdbcProfile) {
     } yield (ds.hash, d.sig),
   )
 
+  val deploysCompiled = Compiled(qDeploys.map(identity))
+
   /** Block */
 
   val blocks = Compiled(qBlocks.map(_.hash))
@@ -51,9 +53,15 @@ final case class Queries(profile: JdbcProfile) {
 
   val blockByHash = Compiled((hash: Rep[Array[Byte]]) => qBlocks.filter(_.hash === hash))
 
+  val blocksCompiled = Compiled(qBlocks.map(identity))
+
   /** DeploySet */
 
   val deploySetIdByHash = Compiled((hash: Rep[Array[Byte]]) => qDeploySets.filter(_.hash === hash).map(_.id))
+
+  val deploySetsCompiled = Compiled(qDeploySets.map(_.hash))
+
+  val deploySetBindsCompiled = Compiled(qDeploySetBinds.map(identity))
 
   /** BlockSet */
 
@@ -66,6 +74,10 @@ final case class Queries(profile: JdbcProfile) {
       b   <- qBlocks if b.id === bsb.blockId
     } yield (bs.hash, b.hash),
   )
+
+  val blockSetsCompiled = Compiled(qBlockSets.map(_.hash))
+
+  val blockSetBindsCompiled = Compiled(qBlockSetBinds.map(identity))
 
   /** BondsMap */
 


### PR DESCRIPTION
## Overview

After the simulator switched from the H2 DBMS, which ran in memory, to PostgreSQL, which runs a database on disk, the performance of the simulator decreased significantly.

This PR examines bottlenecks, performs optimizations, and evaluates simulator performance gains.

Connection pooling and query compilation are taken into account in the table, but these optimizations were made in previous PRs

### Methodology

The simulator runs with 4 threads on 1 node. Measurements within 3 minutes. The first 50 records are folded back - this is warming up. For the rest, BPS is taken and averaged. FlameGraph is built using the library [async-profiler](https://github.com/async-profiler/async-profiler). Example run

```bash
sudo sysctl kernel.perf_event_paranoid=1
./profiler.sh -d 120 -f flamegraph.html 25483
```

The following Python script is used to calculate average performance:

```python
import re
import subprocess

def read_clipboard():
    return subprocess.check_output('xclip -selection clipboard -o', shell=True).decode("utf-8")

if __name__ == '__main__':
    warmup_count = 50  # skip the first few warm-up values
    float_num_regex = r'\d+\.\d+'

    # read console log from clipboard
    # it should be in clipboard before run this script
    data = read_clipboard()

    # collect numbers from log
    # ::2 means each 2nd value (BPS)
    arr = [float(i) for i in re.findall(float_num_regex, data)[::2]][warmup_count:]

    # calc average and print it
    mean = sum(arr) / len(arr) if len(arr) > 0 else 0
    print(f'mean = {mean}')
```

### Results

| Optimization type                       |   BPS   |      coef      |
|-----------------------------------------|---------|----------------|
| Before optimizations                    | 3.20    |                |
| With compiled queries                   | 8.15    | x 2.55         |
| With pooled DB connections              | 40.80   | x 5.00 (12.75) |
| With optimization of get by PK sequence | 52.16   | x 1.28 (16.30) |
| With optimization of inserts            | 61.24   | x 1.17 (19.14) |
| In-memory DB (gauge)                    | ~161.80 |                |

Unfortunately, GitHub does not allow you to download html files from FlameGraph, so I provide screenshots before and after optimization. Slick calls are highlighted in the graphs.

![image](https://github.com/bigsur-network/node/assets/1443855/c4b4676e-c2d4-46c3-a97d-a41524d48146)

![image](https://github.com/bigsur-network/node/assets/1443855/6b5d5cde-9ee4-420e-ad18-07a7b8a1ec38)


### Please make sure that this PR:

- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
