### PR TITLE
Add peers support in DB

### DIFF
--- a/db/src/main/scala/slick/Queries.scala
+++ b/db/src/main/scala/slick/Queries.scala
@@ -98,4 +98,10 @@ final case class Queries(profile: JdbcProfile) {
   val validatorIdByPK = Compiled((pK: Rep[Array[Byte]]) => qValidators.filter(_.pubKey === pK).map(_.id))
 
   val validatorPkById = Compiled((validatorId: Rep[Long]) => qValidators.filter(_.id === validatorId).map(_.pubKey))
+
+  /** Peer */
+
+  val peersCompiled = Compiled(qPeers.map(identity))
+
+  val peerIdByPk = Compiled((url: Rep[String]) => qPeers.filter(_.url === url).map(_.id))
 }

--- a/db/src/main/scala/slick/api/data/Peer.scala
+++ b/db/src/main/scala/slick/api/data/Peer.scala
@@ -1,0 +1,6 @@
+package slick.api.data
+
+final case class Peer(
+  url: String,
+  isSelf: Boolean,
+)

--- a/db/src/main/scala/slick/api/data/Peer.scala
+++ b/db/src/main/scala/slick/api/data/Peer.scala
@@ -1,6 +1,0 @@
-package slick.api.data
-
-final case class Peer(
-  url: String,
-  isSelf: Boolean,
-)

--- a/db/src/main/scala/slick/migrations/TablePeers.scala
+++ b/db/src/main/scala/slick/migrations/TablePeers.scala
@@ -1,0 +1,9 @@
+package slick.migrations
+
+import slick.migration.api.{Dialect, ReversibleMigrationSeq, TableMigration}
+import slick.qPeers
+
+object TablePeers {
+  def apply(implicit dialect: Dialect[?]): ReversibleMigrationSeq =
+    new ReversibleMigrationSeq(TableMigration(qPeers).create.addColumns(_.id, _.url, _.isSelf))
+}

--- a/db/src/main/scala/slick/migrations/TablePeers.scala
+++ b/db/src/main/scala/slick/migrations/TablePeers.scala
@@ -5,5 +5,5 @@ import slick.qPeers
 
 object TablePeers {
   def apply(implicit dialect: Dialect[?]): ReversibleMigrationSeq =
-    new ReversibleMigrationSeq(TableMigration(qPeers).create.addColumns(_.id, _.url, _.isSelf))
+    new ReversibleMigrationSeq(TableMigration(qPeers).create.addColumns(_.id, _.url, _.isSelf, _.isValidator))
 }

--- a/db/src/main/scala/slick/migrations/package.scala
+++ b/db/src/main/scala/slick/migrations/package.scala
@@ -11,5 +11,6 @@ package object migrations {
   def all(dialect: Dialect[?]): SortedMap[Int, MigrationSeq] =
     SortedMap(
       1 -> Baseline(dialect),
+      2 -> TablePeers(dialect),
     )
 }

--- a/db/src/main/scala/slick/package.scala
+++ b/db/src/main/scala/slick/package.scala
@@ -15,4 +15,5 @@ package object slick {
   val qShards         = TableQuery[TableShards]
   val qValidators     = TableQuery[TableValidators]
   val qConfigs        = TableQuery[TableConfig]
+  val qPeers          = TableQuery[TablePeers]
 }

--- a/db/src/main/scala/slick/tables/TablePeers.scala
+++ b/db/src/main/scala/slick/tables/TablePeers.scala
@@ -1,0 +1,21 @@
+package slick.tables
+
+import slick.jdbc.PostgresProfile.api.*
+import slick.lifted.ProvenShape
+import slick.tables.TablePeers.Peer
+
+class TablePeers(tag: Tag) extends Table[Peer](tag, "peer") {
+  def id: Rep[Long]        = column[Long]("id", O.AutoInc, O.PrimaryKey)
+  def url: Rep[String]     = column[String]("url", O.Unique)
+  def isSelf: Rep[Boolean] = column[Boolean]("isSelf")
+
+  override def * : ProvenShape[Peer] = (id, url, isSelf).mapTo[Peer]
+}
+
+object TablePeers {
+  final case class Peer(
+    id: Long,
+    url: String,
+    isSelf: Boolean,
+  )
+}

--- a/db/src/main/scala/slick/tables/TablePeers.scala
+++ b/db/src/main/scala/slick/tables/TablePeers.scala
@@ -5,11 +5,12 @@ import slick.lifted.ProvenShape
 import slick.tables.TablePeers.Peer
 
 class TablePeers(tag: Tag) extends Table[Peer](tag, "peer") {
-  def id: Rep[Long]        = column[Long]("id", O.AutoInc, O.PrimaryKey)
-  def url: Rep[String]     = column[String]("url", O.Unique)
-  def isSelf: Rep[Boolean] = column[Boolean]("isSelf")
+  def id: Rep[Long]             = column[Long]("id", O.AutoInc, O.PrimaryKey)
+  def url: Rep[String]          = column[String]("url", O.Unique)
+  def isSelf: Rep[Boolean]      = column[Boolean]("isSelf")
+  def isValidator: Rep[Boolean] = column[Boolean]("isValidator")
 
-  override def * : ProvenShape[Peer] = (id, url, isSelf).mapTo[Peer]
+  override def * : ProvenShape[Peer] = (id, url, isSelf, isValidator).mapTo[Peer]
 }
 
 object TablePeers {
@@ -17,5 +18,6 @@ object TablePeers {
     id: Long,
     url: String,
     isSelf: Boolean,
+    isValidator: Boolean,
   )
 }

--- a/sdk/src/main/scala/sdk/comm/Peer.scala
+++ b/sdk/src/main/scala/sdk/comm/Peer.scala
@@ -1,0 +1,14 @@
+package sdk.comm
+
+final case class Peer(
+  url: String,
+  isSelf: Boolean,
+  isValidator: Boolean,
+) {
+  override def equals(obj: Any): Boolean = obj match {
+    case Peer(url, _, _) => this.url == url
+    case _               => false
+  }
+
+  override def hashCode(): Int = url.hashCode
+}


### PR DESCRIPTION
## Overview

Adds `peer` table to DB and appropriate actions, queries, unit tests and migration to be able to store list of node peers in the database.

### Please make sure that this PR:

- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
