### PR TITLE
Initial implementation of P2P communication module

### DIFF
--- a/db/src/main/scala/slick/migrations/TablePeers.scala
+++ b/db/src/main/scala/slick/migrations/TablePeers.scala
@@ -5,5 +5,9 @@ import slick.qPeers
 
 object TablePeers {
   def apply(implicit dialect: Dialect[?]): ReversibleMigrationSeq =
-    new ReversibleMigrationSeq(TableMigration(qPeers).create.addColumns(_.id, _.url, _.isSelf, _.isValidator))
+    new ReversibleMigrationSeq(
+      TableMigration(qPeers).create
+        .addColumns(_.id, _.url, _.isSelf, _.isValidator)
+        .addIndexes(_.idx),
+    )
 }

--- a/db/src/main/scala/slick/tables/TablePeers.scala
+++ b/db/src/main/scala/slick/tables/TablePeers.scala
@@ -10,6 +10,8 @@ class TablePeers(tag: Tag) extends Table[Peer](tag, "peer") {
   def isSelf: Rep[Boolean]      = column[Boolean]("isSelf")
   def isValidator: Rep[Boolean] = column[Boolean]("isValidator")
 
+  def idx = index("idx_peer_url", url, unique = true)
+
   override def * : ProvenShape[Peer] = (id, url, isSelf, isValidator).mapTo[Peer]
 }
 

--- a/node/src/main/scala/node/comm/CommImpl.scala
+++ b/node/src/main/scala/node/comm/CommImpl.scala
@@ -5,19 +5,24 @@ import cats.syntax.all.*
 import dproc.DProc
 import sdk.comm.{Comm, Peer}
 
-final class CommImpl[F[_]: Sync, M, T](
+final class CommImpl[F[_]: Sync, A, B, T] private (
   private val peerTable: PeerTable[F, String, Peer],
 
   /** In the future we will only need the peer URL to send a message,
    * but for now in the simulator we need an instance of the process */
-  private val peerProc: Map[String, DProc[F, M, T]],
-) extends Comm[F, M] {
+  private val peerProc: Map[String, DProc[F, A, T]],
+) extends Comm[F, A, B] {
 
-  override def broadcast(msg: M): F[Unit] = for {
+  override def broadcast(msg: A): F[Unit] = for {
     peers <- peerTable.all.map(_.values.toSeq)
     _     <- peers.filterNot(_.isSelf).traverse(peer => peerProc.get(peer.url).map(_.acceptMsg(msg)).getOrElse(().pure))
   } yield ()
 
   // NOTE: Not used yet, so empty
-  override def receiver: fs2.Stream[F, Unit] = fs2.Stream.empty
+  override def receiver: fs2.Stream[F, B] = fs2.Stream.empty
+}
+
+object CommImpl {
+  def apply[F[_]: Sync, A, B, T](peerTable: PeerTable[F, String, Peer], peerProc: Map[String, DProc[F, A, T]]) =
+    new CommImpl[F, A, B, T](peerTable, peerProc)
 }

--- a/node/src/main/scala/node/comm/CommImpl.scala
+++ b/node/src/main/scala/node/comm/CommImpl.scala
@@ -1,0 +1,23 @@
+package node.comm
+
+import cats.effect.Sync
+import cats.syntax.all.*
+import dproc.DProc
+import sdk.comm.{Comm, Peer}
+
+final class CommImpl[F[_]: Sync, M, T](
+  private val peerTable: PeerTable[F, String, Peer],
+
+  /** In the future we will only need the peer URL to send a message,
+   * but for now in the simulator we need an instance of the process */
+  private val peerProc: Map[String, DProc[F, M, T]],
+) extends Comm[F, M] {
+
+  override def broadcast(msg: M): F[Unit] = for {
+    peers <- peerTable.all.map(_.values.toSeq)
+    _     <- peers.filterNot(_.isSelf).traverse(peer => peerProc.get(peer.url).map(_.acceptMsg(msg)).getOrElse(().pure))
+  } yield ()
+
+  // NOTE: Not used yet, so empty
+  override def receiver: fs2.Stream[F, Unit] = fs2.Stream.empty
+}

--- a/node/src/main/scala/node/comm/Config.scala
+++ b/node/src/main/scala/node/comm/Config.scala
@@ -3,7 +3,7 @@ package node.comm
 import node.comm.Config.PeerCfg
 import sdk.reflect.Description
 
-@Description("peerCfg")
+@Description("commCfg")
 final case class Config(
   @Description("Initial list of node peers")
   peers: List[PeerCfg] = List.empty[PeerCfg],

--- a/node/src/main/scala/node/comm/Config.scala
+++ b/node/src/main/scala/node/comm/Config.scala
@@ -1,0 +1,23 @@
+package node.comm
+
+import node.comm.Config.PeerCfg
+import sdk.reflect.Description
+
+@Description("peerCfg")
+final case class Config(
+  @Description("Initial list of node peers")
+  peers: List[PeerCfg] = List.empty[PeerCfg],
+)
+
+object Config {
+  final case class PeerCfg(
+    url: String,
+    isSelf: Boolean,
+    isValidator: Boolean,
+  ) {
+    override def toString = s"""{url: "$url", isSelf: $isSelf, isValidator: $isValidator}"""
+  }
+
+  // Default config has an example value as a basis when filling config manually
+  val Default: Config = Config(List(PeerCfg("url", isSelf = false, isValidator = true)))
+}

--- a/node/src/main/scala/node/comm/PeerTable.scala
+++ b/node/src/main/scala/node/comm/PeerTable.scala
@@ -7,7 +7,7 @@ import sdk.comm.Peer
 import slick.SlickDb
 import slick.syntax.all.DBIOActionRunSyntax
 
-final class PeerTable[F[_]: Sync, PId, P](
+final class PeerTable[F[_]: Sync, PId, P] private (
   private val stRef: Ref[F, ST[PId, P]],
   loadPeersF: () => F[Seq[P]],
   storePeerF: P => F[Unit],
@@ -30,7 +30,7 @@ final class PeerTable[F[_]: Sync, PId, P](
 object PeerTable {
   final case class ST[PId, P](peers: Map[PId, P])
 
-  def load[F[_]: Async](cfg: Config)(implicit db: SlickDb): F[PeerTable[F, String, Peer]] = for {
+  def apply[F[_]: Async](cfg: Config)(implicit db: SlickDb): F[PeerTable[F, String, Peer]] = for {
     api     <- slick.api.SlickApi[F].apply(db)
     dbPeers <- api.actions.peers.run
     state   <- if (dbPeers.isEmpty) {

--- a/node/src/main/scala/node/comm/PeerTable.scala
+++ b/node/src/main/scala/node/comm/PeerTable.scala
@@ -1,0 +1,56 @@
+package node.comm
+
+import cats.effect.{Async, Ref, Sync}
+import cats.syntax.all.*
+import node.comm.PeerTable.ST
+import sdk.comm.Peer
+import slick.SlickDb
+import slick.syntax.all.DBIOActionRunSyntax
+
+final class PeerTable[F[_]: Sync, PId, P](
+  private val stRef: Ref[F, ST[PId, P]],
+  loadPeersF: () => F[Seq[P]],
+  storePeerF: P => F[Unit],
+  removePeerF: P => F[Unit],
+) {
+  def add(peers: Map[PId, P]): F[Unit] = stRef.update(state => ST(state.peers ++ peers)) *> updatePeers()
+  def remove(keys: Set[PId]): F[Unit]  = stRef.update(state => ST(state.peers -- keys)) *> updatePeers()
+  def all: F[Map[PId, P]]              = stRef.get.map(_.peers)
+
+  private def updatePeers(): F[Unit] = for {
+    dbPeers  <- loadPeersF()
+    refPeers <- stRef.get.map(_.peers.values.toSeq)
+    toInsert  = refPeers.filter(p => !dbPeers.contains(p))
+    toRemove  = dbPeers.filter(p => !refPeers.contains(p))
+    _        <- toInsert.traverse(storePeerF)
+    _        <- toRemove.traverse(removePeerF)
+  } yield ()
+}
+
+object PeerTable {
+  final case class ST[PId, P](peers: Map[PId, P])
+
+  def load[F[_]: Async](cfg: Config)(implicit db: SlickDb): F[PeerTable[F, String, Peer]] = for {
+    api     <- slick.api.SlickApi[F].apply(db)
+    dbPeers <- api.actions.peers.run
+    state   <- if (dbPeers.isEmpty) {
+                 // At the first start, when there are no peers in the DB,
+                 // read them from the configuration file and save in the DB
+                 val peerTable = PeerTable.ST[String, Peer](cfg.peers.map { p =>
+                   p.url -> Peer(p.url, p.isSelf, p.isValidator)
+                 }.toMap)
+                 cfg.peers
+                   .traverse(p => api.actions.peerInsertIfNot(p.url, p.isSelf, p.isValidator).run)
+                   .as(peerTable)
+               } else {
+                 // During the next launches use peers from the DB
+                 PeerTable.ST[String, Peer](dbPeers.map(p => p.url -> p).toMap).pure
+               }
+    stRef   <- Ref[F].of(state)
+  } yield new PeerTable(
+    stRef,
+    () => api.actions.peers.run,
+    (peer: Peer) => api.actions.peerInsertIfNot(peer.url, peer.isSelf, peer.isValidator).run.void,
+    (peer: Peer) => api.actions.removePeer(peer.url).run.void,
+  )
+}

--- a/node/src/main/scala/node/comm/PeerTable.scala
+++ b/node/src/main/scala/node/comm/PeerTable.scala
@@ -14,8 +14,8 @@ final class PeerTable[F[_]: Sync, PId, P] private (
   storePeerF: P => F[Unit],
   removePeerF: P => F[Unit],
 ) {
-  def add(peers: Map[PId, P]): F[Unit] = stCell.evalUpdate(state => updatePeers() *> ST(state.peers ++ peers).pure)
-  def remove(keys: Set[PId]): F[Unit]  = stCell.evalUpdate(state => updatePeers() *> ST(state.peers -- keys).pure)
+  def add(peers: Map[PId, P]): F[Unit] = stCell.evalUpdate(state => updatePeers().as(ST(state.peers ++ peers)))
+  def remove(keys: Set[PId]): F[Unit]  = stCell.evalUpdate(state => updatePeers().as(ST(state.peers -- keys)))
   def all: F[Map[PId, P]]              = stCell.get.map(_.peers)
 
   private def updatePeers(): F[Unit] = for {

--- a/sdk/src/main/scala/sdk/comm/Comm.scala
+++ b/sdk/src/main/scala/sdk/comm/Comm.scala
@@ -1,9 +1,11 @@
 package sdk.comm
 
-/** Node's P2P communication module
- * Sends given message to all known peers except self via `broadcast` method
- * Receives messages from network with `receiver` stream */
-trait Comm[F[_], M] {
-  def broadcast(msg: M): F[Unit]
-  def receiver: fs2.Stream[F, Unit]
+/**
+ * Interface for communication with peers.
+ * @tparam A inbound message type
+ * @tparam B outbound message type
+ */
+trait Comm[F[_], A, B] {
+  def broadcast(msg: A): F[Unit]
+  def receiver: fs2.Stream[F, B]
 }

--- a/sdk/src/main/scala/sdk/comm/Comm.scala
+++ b/sdk/src/main/scala/sdk/comm/Comm.scala
@@ -1,0 +1,9 @@
+package sdk.comm
+
+/** Node's P2P communication module
+ * Sends given message to all known peers except self via `broadcast` method
+ * Receives messages from network with `receiver` stream */
+trait Comm[F[_], M] {
+  def broadcast(msg: M): F[Unit]
+  def receiver: fs2.Stream[F, Unit]
+}

--- a/sdk/src/main/scala/sdk/reflect/ClassesAsConfig.scala
+++ b/sdk/src/main/scala/sdk/reflect/ClassesAsConfig.scala
@@ -17,8 +17,9 @@ object ClassesAsConfig {
       ClassAsTuple(clz)
         .map { case (name, value, anno) =>
           val formattedValue = value match {
-            case s: String => s""""$s""""
-            case _         => value.toString
+            case s: String  => s""""$s""""
+            case l: List[_] => s"[\n${l.map(_.toString).mkString(",\n")}\n]"
+            case _          => value.toString
           }
           s"""|# $anno
               |$root.$configName.$name: $formattedValue

--- a/sdk/src/main/scala/sdk/reflect/ClassesAsConfig.scala
+++ b/sdk/src/main/scala/sdk/reflect/ClassesAsConfig.scala
@@ -17,9 +17,9 @@ object ClassesAsConfig {
       ClassAsTuple(clz)
         .map { case (name, value, anno) =>
           val formattedValue = value match {
-            case s: String  => s""""$s""""
-            case l: List[_] => s"[\n${l.map(_.toString).mkString(",\n")}\n]"
-            case _          => value.toString
+            case s: String => s""""$s""""
+            case l: Seq[_] => s"[\n  ${l.map(_.toString).mkString(",\n  ")}\n]"
+            case _         => value.toString
           }
           s"""|# $anno
               |$root.$configName.$name: $formattedValue

--- a/sim/src/main/resources/reference.conf
+++ b/sim/src/main/resources/reference.conf
@@ -49,3 +49,8 @@ gorki.dbCfg.initialConnections: 10
 gorki.dbCfg.maxIdleConnections: 10
 # Maximum total number of idle and borrows DB connections that can be active at the same time
 gorki.dbCfg.maxTotalConnections: 20
+
+# Initial list of node peers
+gorki.peerCfg.peers: [
+{url: "url", isSelf: false, isValidator: true}
+]

--- a/sim/src/main/resources/reference.conf
+++ b/sim/src/main/resources/reference.conf
@@ -51,6 +51,6 @@ gorki.dbCfg.maxIdleConnections: 10
 gorki.dbCfg.maxTotalConnections: 20
 
 # Initial list of node peers
-gorki.peerCfg.peers: [
-{url: "url", isSelf: false, isValidator: true}
+gorki.commCfg.peers: [
+  {url: "url", isSelf: false, isValidator: true}
 ]

--- a/sim/src/test/scala/ReferenceConf.scala
+++ b/sim/src/test/scala/ReferenceConf.scala
@@ -9,6 +9,7 @@ class ReferenceConf extends AnyFlatSpec {
       node.Config.Default,
       diagnostics.metrics.Config.Default,
       db.Config.Default,
+      node.comm.Config.Default,
     )
     println(s)
   }


### PR DESCRIPTION
## Overview

Adds initial implementation of `Comm` module. Uses a configuration file to load peers on first run. Then peers are saved in the database in the `peer` table and read from this table during another runs.

Since the `comm` object is created single for the entire simulator, it is not possible to separately specify the `isSelf` attribute for each node, so in the configuration file it is necessary to set `isSelf=false` for all peers for the simulation to work.

Added support for printing lists in settings.

To ensure the uniqueness of the `url` field in the `peer` table, a corresponding index was added.

### Please make sure that this PR:

- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
